### PR TITLE
fix module name to github.com/openinfradev/tks-contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,8 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
+.idea/
+.DS_Store
+.vscode/
+

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
-module tks-contract
+module github.com/openinfradev/tks-contract
 
 go 1.16
 
 require (
 	github.com/google/uuid v1.2.0
-	github.com/openinfradev/tks-contract v0.0.0
 	github.com/openinfradev/tks-proto v0.0.3
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/grpc v1.36.1


### PR DESCRIPTION
Add vendor directory in .gitignore file
fix module name to github.com/openinfradev/tks-contract